### PR TITLE
Fix overlay layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -204,7 +204,7 @@ export default function Home() {
 
       {/* デバッグ情報（開発時のみ表示） */}
       {process.env.NODE_ENV === 'development' && (
-        <div className="absolute bottom-24 left-4 bg-black bg-opacity-80 text-white p-2 rounded text-xs">
+        <div className="absolute bottom-4 left-4 bg-black bg-opacity-80 text-white p-2 rounded text-xs">
           <div>現在のポーズ: {currentPose?.name || 'なし'}</div>
           <div>保存済みポーズ数: {poses.length}</div>
           <div>操作モード: {operationMode}</div>

--- a/src/components/Canvas3D.tsx
+++ b/src/components/Canvas3D.tsx
@@ -913,7 +913,7 @@ export default function Canvas3D({
       )}
 
       {/* 現在のモード表示 */}
-      <div className="absolute bottom-4 left-4 bg-black bg-opacity-70 text-white p-2 rounded text-sm">
+      <div className="absolute bottom-4 right-4 bg-black bg-opacity-70 text-white p-2 rounded text-sm">
         現在のモード: {operationMode}
         {operationMode === 'view' && <div className="text-xs text-gray-300">マウスで視点操作可能</div>}
         {operationMode === 'transform' && (


### PR DESCRIPTION
## Summary
- avoid overlaying panels for mode and pose
- show current pose panel at bottom left
- move current mode panel to bottom right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884eca96f84832aa0f7b1a72e67bd61