### PR TITLE
Add click-based mode switching

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -114,6 +114,7 @@ export default function EditorPage() {
         modelUrl="/model.glb"
         backgroundImageUrl={course.background || '/wall.jpg'}
         operationMode={mode}
+        onModeChange={setMode}
         onPoseChange={handlePoseChange}
         resetTrigger={resetTrigger}
         presetPose={preset}


### PR DESCRIPTION
## Summary
- allow Canvas3D to notify parent about mode change
- detect head clicks to toggle pose and transform modes
- use canvas pointer misses to revert to view mode
- pass new handler from editor page

## Testing
- `npm install`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885943ba894832aaa6f580cd7f3b389