### PR TITLE
トップ画面文言修正と戻るボタン追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
         <button onClick={handleCreate} className="px-4 py-2 bg-blue-600 rounded text-white mt-2">作成</button>
       </div>
       <div className="p-4 bg-gray-800 rounded">
-        <h2 className="font-semibold mb-2">既存コース</h2>
+        <h2 className="font-semibold mb-2">作成済コース</h2>
         {courses.length === 0 && <p>保存されたコースはありません</p>}
         <ul className="space-y-2">
           {courses.map(c => (

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { useRouter } from 'next/navigation'
 
 export type OperationMode = 'view' | 'transform' | 'pose'
 
@@ -17,6 +18,7 @@ export default function Toolbar({
   onResetPose,
   onPresetPose
 }: ToolbarProps) {
+  const router = useRouter()
   const modeConfig = {
     view: {
       icon: '👁️',
@@ -38,8 +40,14 @@ export default function Toolbar({
   return (
     <div className="absolute top-4 left-4 bg-black bg-opacity-80 text-white rounded-lg shadow-lg">
       {/* ヘッダー */}
-      <div className="px-4 py-3 border-b border-gray-600">
+      <div className="px-4 py-3 border-b border-gray-600 flex items-center justify-between">
         <h2 className="text-lg font-bold">ボルダリングポーズ検討</h2>
+        <button
+          onClick={() => router.push('/')}
+          className="px-2 py-1 text-sm bg-blue-600 rounded hover:bg-blue-500"
+        >
+          トップへ戻る
+        </button>
       </div>
 
       {/* モード切り替えボタン */}


### PR DESCRIPTION
## Summary
- トップ画面の見出しを「作成済コース」に変更
- エディター画面のツールバーに「トップへ戻る」ボタンを追加

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885bb31570c832ab04b92847076c77a