### PR TITLE
頭部クリックインジケータ追加とショートカット表示調整

### DIFF
--- a/src/components/Canvas3D.tsx
+++ b/src/components/Canvas3D.tsx
@@ -465,15 +465,23 @@ function KeyboardHandler({
 // 頭部クリック検出用コンポーネント
 function HeadClickTarget({
   bone,
+  operationMode,
   onSingle,
   onDouble
 }: {
   bone: THREE.Bone | null
+  operationMode: OperationMode
   onSingle: () => void
   onDouble: () => void
 }) {
   const meshRef = useRef<THREE.Mesh>(null)
   const clickTimer = useRef<NodeJS.Timeout | null>(null)
+
+  const modeColors: Record<OperationMode, string> = {
+    view: '#888888',
+    transform: '#f87171',
+    pose: '#4ecdc4'
+  }
 
   useFrame(() => {
     if (meshRef.current && bone) {
@@ -500,7 +508,11 @@ function HeadClickTarget({
   return (
     <mesh ref={meshRef} onClick={handleClick} onDoubleClick={handleDoubleClick}>
       <sphereGeometry args={[0.25, 8, 8]} />
-      <meshBasicMaterial transparent opacity={0} />
+      <meshBasicMaterial
+        color={modeColors[operationMode]}
+        transparent
+        opacity={0.4}
+      />
     </mesh>
   )
 }
@@ -818,6 +830,7 @@ function HumanModel({
       {headBone && (
         <HeadClickTarget
           bone={headBone}
+          operationMode={operationMode}
           onSingle={() => onModeChange && onModeChange('pose')}
           onDouble={() => onModeChange && onModeChange('transform')}
         />

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -77,7 +77,6 @@ export default function Toolbar({
         {currentMode === 'transform' && (
           <div className="mt-3 pt-3 border-t border-gray-600">
             <div className="text-xs text-gray-400">
-              <div className="mb-1">キーボードショートカット:</div>
               <div>• R：回転モード</div>
               <div>• T：移動モード</div>
               <div>• S：スケールモード</div>


### PR DESCRIPTION
## 概要
- 頭部クリックターゲットにモード毎の色を付けて視認性を向上
- ツールバーの「キーボードショートカット」ラベルを削除

## テスト
- `npm test` を実行し、既存テストが成功することを確認
- `npm run build` はフォント取得のブロックにより失敗

------
https://chatgpt.com/codex/tasks/task_e_6885c64cf428832a81b3bf45b8ac83ae