### PR TITLE
Transform pivot adjustment

### DIFF
--- a/src/components/Canvas3D.tsx
+++ b/src/components/Canvas3D.tsx
@@ -592,11 +592,19 @@ function HumanModel({
       setHeadBone(head)
       setOriginalPose(originalBoneData)
 
-      // ウエスト位置を計算
-      const bbox = new THREE.Box3().setFromObject(gltf.scene)
-      const height = bbox.max.y - bbox.min.y
-      const waist = new THREE.Vector3(0, bbox.min.y + height * 0.5, 0)
-      setWaistOffset(waist)
+      // ウエスト位置を計算（骨があれば優先）
+      const pelvis = magicPoserJoints.find(b => /pelvis|hips/i.test(b.name))
+      if (pelvis) {
+        gltf.scene.updateMatrixWorld(true)
+        const pelvisPos = new THREE.Vector3()
+        pelvis.getWorldPosition(pelvisPos)
+        setWaistOffset(pelvisPos)
+      } else {
+        const bbox = new THREE.Box3().setFromObject(gltf.scene)
+        const height = bbox.max.y - bbox.min.y
+        const waist = new THREE.Vector3(0, bbox.min.y + height * 0.5, 0)
+        setWaistOffset(waist)
+      }
 
       // モデル位置設定はJSX側で行うため、ここではオフセットのみ更新
 


### PR DESCRIPTION
## Summary
- locate TransformControls at the pelvis when available
- fallback to bounding box center otherwise

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885ca6f5054832a9e415857a2669611