### PR TITLE
手首・足首ノードの回転を無効化

### DIFF
--- a/src/components/Canvas3D.tsx
+++ b/src/components/Canvas3D.tsx
@@ -795,20 +795,22 @@ function HumanModel({
         target.updateMatrixWorld(true)
       }
 
-      // まず対象の関節を回転
-      applyRotation(bone, 1)
+      const isExtremity = /hand/i.test(bone.name) || /foot/i.test(bone.name)
 
-      // 手首や足首の場合は親関節も連動させる
-      if (/hand/i.test(bone.name) || /foot/i.test(bone.name)) {
+      if (isExtremity) {
+        // 手首・足首ノードでは自身の回転を行わず、親関節を回転させる
         let parent = bone.parent
         let depth = 0
         while (parent && depth < 2) {
           if (parent instanceof THREE.Bone) {
-            applyRotation(parent, 0.5)
+            applyRotation(parent, 1)
             depth++
           }
           parent = parent.parent
         }
+      } else {
+        // 通常の関節は自身を回転させる
+        applyRotation(bone, 1)
       }
 
       if (onPoseChange) {


### PR DESCRIPTION
## Summary
- 手首・足首をドラッグした際はその関節自体を回転させず、親関節のみ回転するように変更

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885e1063abc832a8eddb1473bd8a749