### PR TITLE
関節ドラッグ時の回転軸を修正

### DIFF
--- a/src/components/Canvas3D.tsx
+++ b/src/components/Canvas3D.tsx
@@ -785,11 +785,11 @@ function HumanModel({
     ) => {
       const SENSITIVITY = 0.02
 
-      const upAxis = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion)
+      const forwardAxis = new THREE.Vector3(0, 0, -1).applyQuaternion(camera.quaternion)
       const rightAxis = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion)
 
       const applyRotation = (target: THREE.Bone, ratio: number) => {
-        target.rotateOnWorldAxis(upAxis, screenDelta.x * SENSITIVITY * ratio)
+        target.rotateOnWorldAxis(forwardAxis, screenDelta.x * SENSITIVITY * ratio)
         target.rotateOnWorldAxis(rightAxis, -screenDelta.y * SENSITIVITY * ratio)
         target.updateMatrix()
         target.updateMatrixWorld(true)


### PR DESCRIPTION
## 概要
- 足首ドラッグで股関節が後方へ回ってしまう問題を修正
- 画面水平方向のドラッグ時、回転軸をカメラ前方方向に変更

## テスト
- `npm test` を実行し、既存テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_68861e0a9b90832a95d8046c1faf5073